### PR TITLE
CON-3539: correct casing in example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ module "acr-config" {
 } 
 
 output "tenant_id" {
-    value = module.acr-config.tenantId
+    value = module.acr-config.tenant_id
 }
 ```
 


### PR DESCRIPTION
This module produces an output named `tenant_id`, not `tenantId` as the example code in the README suggests.