### PR TITLE
CON-6795: Update azurerm & azuread provider versions in Azure ACR Terraform module

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,11 @@ output "tenant_id" {
 | -------- | ----------- |
 | tenant_id | Tenant ID   |
 
+> [!NOTE]
+> If you're using version >= 0.1.3 of this module, you'll have to set the ARM_SUBSCRIPTION_ID environment variable.
+
 ```
+$ export ARM_SUBSCRIPTION_ID=00000000-0000-0000-0000-000000000000 # Only needed when using version >= 0.1.3 of this module, replace null uuid with actual subscription id
 $ terraform init --upgrade
 $ terraform plan  # Please verify before applying
 $ terraform apply

--- a/README.md
+++ b/README.md
@@ -69,10 +69,11 @@ output "tenant_id" {
 | tenant_id | Tenant ID   |
 
 > [!NOTE]
-> If you're using version >= `0.1.3` of this module, you'll have to set the ARM_SUBSCRIPTION_ID environment variable.
+> If you're using version >= `0.1.3` of this module, you'll have to set the `ARM_SUBSCRIPTION_ID` environment variable.
 
 ```
-$ export ARM_SUBSCRIPTION_ID=00000000-0000-0000-0000-000000000000 # Only needed when using version >= 0.1.3 of this module, replace null uuid with actual subscription id
+# Only needed when using version >= 0.1.3 of this module, replace null uuid with actual subscription id
+$ export ARM_SUBSCRIPTION_ID=00000000-0000-0000-0000-000000000000
 $ terraform init --upgrade
 $ terraform plan  # Please verify before applying
 $ terraform apply

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ output "tenant_id" {
 | tenant_id | Tenant ID   |
 
 > [!NOTE]
-> If you're using version >= 0.1.3 of this module, you'll have to set the ARM_SUBSCRIPTION_ID environment variable.
+> If you're using version >= `0.1.3` of this module, you'll have to set the ARM_SUBSCRIPTION_ID environment variable.
 
 ```
 $ export ARM_SUBSCRIPTION_ID=00000000-0000-0000-0000-000000000000 # Only needed when using version >= 0.1.3 of this module, replace null uuid with actual subscription id

--- a/main.tf
+++ b/main.tf
@@ -5,8 +5,8 @@
 
 # Create a service principal for the Uptycs App
 resource "azuread_service_principal" "service_principal" {
-  application_id = var.uptycs_app_client_id
-  use_existing   = true
+  client_id    = var.uptycs_app_client_id
+  use_existing = true
 }
 
 resource "azurerm_role_definition" "Define_Uptycs_Registry_Reader_Role" {

--- a/main.tf
+++ b/main.tf
@@ -29,20 +29,20 @@ resource "azurerm_role_definition" "Define_Uptycs_Registry_Reader_Role" {
 
 # Give the service principal a Reader role in the Subscription
 resource "azurerm_role_assignment" "attach_reader_role" {
-  principal_id         = azuread_service_principal.service_principal.id
+  principal_id         = azuread_service_principal.service_principal.object_id
   scope                = data.azurerm_subscription.current.id
   role_definition_name = "Reader"
 }
 
 # Give the service principal an AcrPull role in the Subscription
 resource "azurerm_role_assignment" "attach_acrpull_role" {
-  principal_id         = azuread_service_principal.service_principal.id
+  principal_id         = azuread_service_principal.service_principal.object_id
   scope                = data.azurerm_subscription.current.id
   role_definition_name = "AcrPull"
 }
 
 resource "azurerm_role_assignment" "attach_custom_role" {
-  principal_id       = azuread_service_principal.service_principal.id
+  principal_id       = azuread_service_principal.service_principal.object_id
   scope              = data.azurerm_subscription.current.id
   role_definition_id = azurerm_role_definition.Define_Uptycs_Registry_Reader_Role.role_definition_resource_id
 }

--- a/providers.tf
+++ b/providers.tf
@@ -6,11 +6,11 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.39.1"
+      version = "~> 4.43.0"
     }
     azuread = {
       source  = "hashicorp/azuread"
-      version = "~> 2.32.0"
+      version = "~> 3.5.0"
     }
   }
 }


### PR DESCRIPTION
- Updated `azurerm` &rarr; `4.43.0` & `azuread` &rarr; `3.5.0` provider versions in Uptycs Azure ACR Integration Terraform module to match with versions in CSPM Azure TF modules
- Updating the modules to newer versions introduces a breaking change where `azurerm` provider expects the env variable `ARM_SUBSCRIPTION_ID` to be set to a given Azure Subscription ID.
- `terraform apply` output:
```
~/gitlocal/tf_test_files/supernova/azure-container-registry
❯ export ARM_SUBSCRIPTION_ID=00000000-0000-0000-0000-000000000000

~/gitlocal/tf_test_files/supernova/azure-container-registry
❯ echo $ARM_SUBSCRIPTION_ID
00000000-0000-0000-0000-000000000000

~/gitlocal/tf_test_files/supernova/azure-container-registry
❯ terraform init -upgrade
Initializing the backend...
Upgrading modules...
- acr-config in ../../../terraform-azurerm-acr-config
Initializing provider plugins...
- Finding hashicorp/azurerm versions matching "~> 4.43.0"...
- Finding hashicorp/azuread versions matching "~> 3.5.0"...
- Using previously-installed hashicorp/azurerm v4.43.0
- Using previously-installed hashicorp/azuread v3.5.0

Terraform has been successfully initialized!

You may now begin working with Terraform. Try running "terraform plan" to see
any changes that are required for your infrastructure. All Terraform commands
should now work.

If you ever set or change modules or backend configuration for Terraform,
rerun this command to reinitialize your working directory. If you forget, other
commands will detect it and remind you to do so if necessary.

~/gitlocal/tf_test_files/supernova/azure-container-registry
❯ terraform apply
module.acr-config.data.azuread_application_published_app_ids.well_known: Reading...
module.acr-config.data.azuread_application_published_app_ids.well_known: Read complete after 0s [id=appIds]
module.acr-config.data.azurerm_subscription.current: Reading...
module.acr-config.data.azurerm_client_config.current: Reading...
module.acr-config.data.azurerm_client_config.current: Read complete after 0s [id=Y2xpZW50Q29uZmlncy9jbGllbnRJZD0wNGIwNzc5NS04ZGRiLTQ2MWEtYmJlZS0wMmY5ZTFiZjdiNDY7b2JqZWN0SWQ9ODg5ODNjZDQtNWJkMS00YjljLTg5ZTMtODZhZTYxMzk0NDY1O3N1YnNjcmlwdGlvbklkPThkYTMxZDIwLWRhZjktNDJhZC1iZjdmLTJjZGNmNjI5ZDc2OTt0ZW5hbnRJZD1kYThmYjJiYy01MTA0LTQ2ZGQtODI2Mi0zMmVkZmI2NGJkZDc=]
module.acr-config.data.azurerm_subscription.current: Read complete after 0s [id=/subscriptions/00000000-0000-0000-0000-000000000000]

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # module.acr-config.azuread_service_principal.service_principal will be created
  + resource "azuread_service_principal" "service_principal" {
      + account_enabled             = true
      + app_role_ids                = (known after apply)
      + app_roles                   = (known after apply)
      + application_tenant_id       = (known after apply)
      + client_id                   = "00000000-0000-0000-0000-000000000000"
      + display_name                = (known after apply)
      + homepage_url                = (known after apply)
      + id                          = (known after apply)
      + logout_url                  = (known after apply)
      + oauth2_permission_scope_ids = (known after apply)
      + oauth2_permission_scopes    = (known after apply)
      + object_id                   = (known after apply)
      + redirect_uris               = (known after apply)
      + saml_metadata_url           = (known after apply)
      + service_principal_names     = (known after apply)
      + sign_in_audience            = (known after apply)
      + tags                        = (known after apply)
      + type                        = (known after apply)
      + use_existing                = true

      + feature_tags (known after apply)

      + features (known after apply)
    }

  # module.acr-config.azurerm_role_assignment.attach_acrpull_role will be created
  + resource "azurerm_role_assignment" "attach_acrpull_role" {
      + condition_version                = (known after apply)
      + id                               = (known after apply)
      + name                             = (known after apply)
      + principal_id                     = (known after apply)
      + principal_type                   = (known after apply)
      + role_definition_id               = (known after apply)
      + role_definition_name             = "AcrPull"
      + scope                            = "/subscriptions/00000000-0000-0000-0000-000000000000"
      + skip_service_principal_aad_check = (known after apply)
    }

  # module.acr-config.azurerm_role_assignment.attach_custom_role will be created
  + resource "azurerm_role_assignment" "attach_custom_role" {
      + condition_version                = (known after apply)
      + id                               = (known after apply)
      + name                             = (known after apply)
      + principal_id                     = (known after apply)
      + principal_type                   = (known after apply)
      + role_definition_id               = (known after apply)
      + role_definition_name             = (known after apply)
      + scope                            = "/subscriptions/00000000-0000-0000-0000-000000000000"
      + skip_service_principal_aad_check = (known after apply)
    }

  # module.acr-config.azurerm_role_assignment.attach_reader_role will be created
  + resource "azurerm_role_assignment" "attach_reader_role" {
      + condition_version                = (known after apply)
      + id                               = (known after apply)
      + name                             = (known after apply)
      + principal_id                     = (known after apply)
      + principal_type                   = (known after apply)
      + role_definition_id               = (known after apply)
      + role_definition_name             = "Reader"
      + scope                            = "/subscriptions/00000000-0000-0000-0000-000000000000"
      + skip_service_principal_aad_check = (known after apply)
    }

  # module.acr-config.azurerm_role_definition.Define_Uptycs_Registry_Reader_Role will be created
  + resource "azurerm_role_definition" "Define_Uptycs_Registry_Reader_Role" {
      + assignable_scopes           = [
          + "/subscriptions/00000000-0000-0000-0000-000000000000",
        ]
      + description                 = "Read permissions for accessing ACR"
      + id                          = (known after apply)
      + name                        = "uptycs_custom_role"
      + role_definition_id          = (known after apply)
      + role_definition_resource_id = (known after apply)
      + scope                       = "/subscriptions/00000000-0000-0000-0000-000000000000"

      + permissions {
          + actions     = [
              + "Microsoft.ContainerRegistry/registries/read",
              + "Microsoft.ContainerRegistry/registries/pull/read",
            ]
          + not_actions = []
        }
    }

Plan: 5 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + tenant_id = "00000000-0000-0000-0000-000000000000"

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes
```
